### PR TITLE
Fix microphone constraints for Chrome

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,7 +170,14 @@ async function start() {
     canvas.width = canvas.clientWidth;
     canvas.height = canvas.clientHeight;
     audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+            echoCancellation: false,
+            noiseSuppression: false,
+            autoGainControl: false
+        }
+    });
+    await audioCtx.resume();
     const source = audioCtx.createMediaStreamSource(stream);
     analyser = audioCtx.createAnalyser();
     analyser.fftSize = 2048;


### PR DESCRIPTION
## Summary
- disable noise suppression, AGC, and echo cancellation so audio from the same PC can be captured
- explicitly resume the audio context

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887bf0483b8832398d22280d05eacfa