### PR TITLE
Add BPM meter and improve Firefox support

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <div id="app">
         <canvas id="visualizer"></canvas>
         <div id="results"></div>
+        <div id="bpm">BPM: --</div>
         <button id="resetButton">Reset</button>
     </div>
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -73,6 +73,11 @@ body {
     background: rgb(130, 81, 192);
 }
 
+#bpm {
+    margin-top: 10px;
+    font-size: 24px;
+}
+
 .dominate {
     font-size: 1.2em;
     font-weight: bold;


### PR DESCRIPTION
## Summary
- support more browsers by applying audio constraints only if they are recognized
- track beat intervals to estimate BPM
- show BPM readout in the UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887bf0483b8832398d22280d05eacfa