### PR TITLE
Add neon purple chaos background

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,12 +4,28 @@ body {
     color: #eee;
     font-family: Arial, sans-serif;
     overflow: hidden;
+    position: relative;
 }
 
 #app {
     position: relative;
     width: 100%;
     height: 100vh;
+    overflow: hidden;
+}
+
+#app::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    left: -50%;
+    width: 200%;
+    height: 200%;
+    background: radial-gradient(circle at 50% 50%, rgba(100, 51, 162, 0.4), transparent 70%),
+                conic-gradient(from 0deg, rgba(100, 51, 162, 0.3), rgba(0,0,0,0) 90deg);
+    animation: spinBackground 30s linear infinite, pulseBackground 3s ease-in-out infinite alternate;
+    filter: blur(60px);
+    z-index: 0;
 }
 
 #visualizer {
@@ -20,6 +36,7 @@ body {
     height: 100%;
     background: #000;
     border: none;
+    z-index: 1;
 }
 
 #overlay {
@@ -33,6 +50,7 @@ body {
     justify-content: center;
     align-items: center;
     pointer-events: none;
+    z-index: 2;
 }
 
 #info {
@@ -120,6 +138,16 @@ body {
 @keyframes pulse {
     from { box-shadow: 0 0 20px rgba(0,255,170,0.8); }
     to { box-shadow: 0 0 40px rgba(0,255,170,1); }
+}
+
+@keyframes spinBackground {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes pulseBackground {
+    from { opacity: 0.6; }
+    to { opacity: 1; }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- unleash a blur of neon purple behind the app
- layer canvas and overlay so the new chaos stays in the back
- spin and pulse the background with new keyframes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887c45bff4483238c4e80be4288540f