### PR TITLE
Enhance beat visuals and refine BPM detection

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,16 +170,22 @@ function updateBpm(rms) {
     const now = audioCtx.currentTime;
     if (rms > threshold && lastRms <= threshold) {
         if (lastBeatTime) {
-            beatIntervals.push(now - lastBeatTime);
-            if (beatIntervals.length > 8) beatIntervals.shift();
+            const interval = now - lastBeatTime;
+            // ignore unrealistically short or long gaps between beats
+            if (interval > 0.25 && interval < 2) {
+                beatIntervals.push(interval);
+                if (beatIntervals.length > 8) beatIntervals.shift();
+            }
         }
         lastBeatTime = now;
         bpmEl.classList.add('beat');
         resetButton.classList.add('beat');
+        mainKeyEl.classList.add('beat');
         setTimeout(() => {
             bpmEl.classList.remove('beat');
             resetButton.classList.remove('beat');
-        }, 200);
+            mainKeyEl.classList.remove('beat');
+        }, 400);
     }
     lastRms = rms;
     if (beatIntervals.length) {

--- a/style.css
+++ b/style.css
@@ -88,8 +88,9 @@ body {
 }
 
 #bpm.beat,
+#mainKey.beat,
 #resetButton.beat {
-    animation: beatScale 0.2s ease;
+    animation: beatScale 0.4s ease-out;
 }
 
 #resetButton:hover {
@@ -156,8 +157,9 @@ body {
 }
 
 @keyframes beatScale {
-    from { transform: scale(1); }
-    to { transform: scale(1.2); }
+    0% { transform: scale(1); }
+    30% { transform: scale(1.2); }
+    100% { transform: scale(1); }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- slow down the beat animation and include the main key pulse
- ignore unrealistic beat intervals when computing BPM

## Testing
- `node -c script.js`


------
https://chatgpt.com/codex/tasks/task_e_6887c6c4412883239c14d5c61bb67d2c