### PR TITLE
Fix Firefox start issue and add start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
             <button id="resetButton">Reset</button>
             <div id="results"></div>
         </div>
+        <div id="startScreen">
+            <button id="startButton">Start</button>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,8 @@ const resultsEl = document.getElementById('results');
 const bpmEl = document.getElementById('bpm');
 const mainKeyEl = document.getElementById('mainKey');
 const resetButton = document.getElementById('resetButton');
+const startScreen = document.getElementById('startScreen');
+const startButton = document.getElementById('startButton');
 
 const ACCENT_PURPLE = 'rgb(170,0,255)';
 const ACCENT_RED = 'rgb(255,0,80)';
@@ -222,24 +224,29 @@ function process() {
 }
 
 async function start() {
-    setupBars();
-    canvas.width = canvas.clientWidth;
-    canvas.height = canvas.clientHeight;
-    audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const supported = navigator.mediaDevices.getSupportedConstraints();
-    const audioConstraints = {};
-    if (supported.echoCancellation) audioConstraints.echoCancellation = false;
-    if (supported.noiseSuppression) audioConstraints.noiseSuppression = false;
-    if (supported.autoGainControl) audioConstraints.autoGainControl = false;
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
-    await audioCtx.resume();
-    const source = audioCtx.createMediaStreamSource(stream);
-    analyser = audioCtx.createAnalyser();
-    analyser.fftSize = 2048;
-    bufferLength = analyser.fftSize;
-    dataArray = new Float32Array(bufferLength);
-    source.connect(analyser);
-    process();
+    try {
+        setupBars();
+        canvas.width = canvas.clientWidth;
+        canvas.height = canvas.clientHeight;
+        audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        const supported = navigator.mediaDevices.getSupportedConstraints();
+        const audioConstraints = {};
+        if (supported.echoCancellation) audioConstraints.echoCancellation = false;
+        if (supported.noiseSuppression) audioConstraints.noiseSuppression = false;
+        if (supported.autoGainControl) audioConstraints.autoGainControl = false;
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: audioConstraints });
+        await audioCtx.resume();
+        const source = audioCtx.createMediaStreamSource(stream);
+        analyser = audioCtx.createAnalyser();
+        analyser.fftSize = 2048;
+        bufferLength = analyser.fftSize;
+        dataArray = new Float32Array(bufferLength);
+        source.connect(analyser);
+        process();
+    } catch (err) {
+        console.error(err);
+        alert('Microphone access failed: ' + err.message);
+    }
 }
 
 resetButton.addEventListener('click', () => {
@@ -252,4 +259,7 @@ resetButton.addEventListener('click', () => {
     mainKeyEl.textContent = 'Key: --';
 });
 
-window.addEventListener('load', start);
+startButton.addEventListener('click', () => {
+    startScreen.style.display = 'none';
+    start();
+});

--- a/style.css
+++ b/style.css
@@ -14,6 +14,32 @@ body {
     overflow: hidden;
 }
 
+#startScreen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: #000;
+    z-index: 3;
+}
+
+#startButton {
+    pointer-events: auto;
+    padding: 20px 40px;
+    font-size: 24px;
+    border: none;
+    border-radius: 8px;
+    background: rgba(170,0,255,0.4);
+    color: #fff;
+    box-shadow: 0 0 20px rgba(170,0,255,0.8),
+                0 0 40px rgba(255,0,80,0.6);
+    cursor: pointer;
+}
+
 #app::before {
     content: '';
     position: absolute;


### PR DESCRIPTION
## Summary
- add Start screen with start button to require user gesture before using microphone
- handle microphone errors gracefully
- refactor to start analyzer on button click

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887cbdcc6a48323bbdac41612df971a