### PR TITLE
Fix black overlay on background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,7 +26,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    background: #000;
+    background: rgba(0, 0, 0, 0.8);
     z-index: 3;
     transform: translateZ(100px);
 }
@@ -65,7 +65,7 @@ body {
     left: 0;
     width: 100%;
     height: 100%;
-    background: #000;
+    background: transparent;
     border: none;
     z-index: 1;
     transform: rotateX(20deg) translateZ(-50px);


### PR DESCRIPTION
## Summary
- allow background image to show through start screen
- remove black background on the visualizer canvas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887de599f348323b141c565c545f306