### PR TITLE
Remove black fill from vizualizer

### DIFF
--- a/script.js
+++ b/script.js
@@ -121,8 +121,7 @@ function guessKey() {
 }
 
 function drawWave() {
-    ctx.fillStyle = '#000';
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
     const sliceWidth = canvas.width / bufferLength;
     const amplitude = 0.7;
 


### PR DESCRIPTION
## Summary
- don't paint the entire canvas black when drawing waves

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887df51efd083239e136fd805d4b20e