### PR TITLE
Remove label text from key and BPM

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Music Key Detector</title>
     <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Music&display=swap" rel="stylesheet">
 </head>
 <body>
     <div id="app">
         <canvas id="visualizer"></canvas>
         <div id="overlay">
             <div id="info">
-                <div id="mainKey">Key: --</div>
-                <div id="bpm">BPM: --</div>
+                <div id="mainKey">--</div>
+                <div id="bpm">--</div>
             </div>
             <button id="resetButton">Reset</button>
             <div id="results"></div>

--- a/script.js
+++ b/script.js
@@ -171,7 +171,7 @@ function updateResults() {
         if (k === dominant) bars[k].label.classList.add('dominate');
         else bars[k].label.classList.remove('dominate');
     });
-    mainKeyEl.textContent = dominant ? `Key: ${dominant}` : 'Key: --';
+    mainKeyEl.textContent = dominant || '--';
 }
 
 function updateBpm(rms) {
@@ -199,9 +199,9 @@ function updateBpm(rms) {
         const beats = beatTimes.length - 1;
         const avg = span / beats;
         const bpm = Math.round(60 / avg);
-        bpmEl.textContent = `BPM: ${bpm}`;
+        bpmEl.textContent = String(bpm);
     } else {
-        bpmEl.textContent = 'BPM: --';
+        bpmEl.textContent = '--';
     }
 }
 
@@ -253,8 +253,8 @@ resetButton.addEventListener('click', () => {
     beatTimes.length = 0;
     lastBeatTime = 0;
     lastRms = 0;
-    bpmEl.textContent = 'BPM: --';
-    mainKeyEl.textContent = 'Key: --';
+    bpmEl.textContent = '--';
+    mainKeyEl.textContent = '--';
 });
 
 startButton.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
     background: url('background.png') no-repeat center center fixed;
     background-size: cover;
     color: #eee;
-    font-family: Arial, sans-serif;
+    font-family: 'Noto Music', Arial, sans-serif;
     overflow: hidden;
     position: relative;
     perspective: 1000px;
@@ -43,6 +43,12 @@ body {
                 0 0 40px rgba(255,0,80,0.6);
     cursor: pointer;
     transform: translateZ(80px);
+}
+
+#startButton::before {
+    content: "\266B ";
+    font-family: 'Noto Music', sans-serif;
+    margin-right: 4px;
 }
 
 #app::before {
@@ -105,6 +111,12 @@ body {
     transform: translateZ(80px);
 }
 
+#mainKey::before {
+    content: "\1D11E ";
+    font-family: 'Noto Music', sans-serif;
+    margin-right: 6px;
+}
+
 #mainKey::after {
     content: '';
     position: absolute;
@@ -130,6 +142,12 @@ body {
         0 0 30px rgb(255,0,80);
     position: relative;
     transform: translateZ(70px);
+}
+
+#bpm::before {
+    content: "\2669 ";
+    font-family: 'Noto Music', sans-serif;
+    margin-right: 4px;
 }
 
 #bpm::after {
@@ -170,6 +188,17 @@ body {
     position: relative;
     overflow: hidden;
     transform: translateZ(60px);
+}
+
+#resetButton::after {
+    content: "\266A";
+    font-family: 'Noto Music', sans-serif;
+    font-size: 28px;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
 }
 
 #resetButton::before {


### PR DESCRIPTION
## Summary
- clean up display by removing "Key:" and "BPM" labels
- add Noto Music font
- decorate UI elements with musical glyphs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887e0fac47883239c673c344b718a20